### PR TITLE
Disallow making same commitment twice and check blocks order

### DIFF
--- a/packages/contracts/src/DistributedRewardDistribution.sol
+++ b/packages/contracts/src/DistributedRewardDistribution.sol
@@ -109,11 +109,13 @@ contract DistributedRewardsDistribution is AccessControlledPausable, IRewardsDis
   ) external whenNotPaused {
     require(recipients.length == workerRewards.length, "Recipients and worker amounts length mismatch");
     require(recipients.length == _stakerRewards.length, "Recipients and staker amounts length mismatch");
+    require(toBlock >= fromBlock, "toBlock before fromBlock");
 
     require(currentDistributor() == msg.sender, "Not a distributor");
     require(toBlock < block.number, "Future block");
     bytes32 commitment = keccak256(msg.data[4:]);
     require(!alreadyApproved[commitment][msg.sender], "Already approved");
+    require(commitments[fromBlock][toBlock] != commitment, "Commitment already exists");
     commitments[fromBlock][toBlock] = commitment;
     approves[fromBlock][toBlock] = 1;
     alreadyApproved[commitment][msg.sender] = true;

--- a/packages/contracts/test/DistributedRewardsDistribution/DistributedRewardsDistribution.commitAndApprove.t.sol
+++ b/packages/contracts/test/DistributedRewardsDistribution/DistributedRewardsDistribution.commitAndApprove.t.sol
@@ -32,6 +32,13 @@ contract RewardsDistributionCommitApproveTest is RewardsDistributionTest {
     rewardsDistribution.commit(1, 11, recipients, workerAmounts, stakerAmounts);
   }
 
+  function test_RevertsIf_RangeInWrongOrder() public {
+    (uint256[] memory recipients, uint256[] memory workerAmounts, uint256[] memory stakerAmounts) = prepareRewards(1);
+    vm.roll(10);
+    vm.expectRevert("toBlock before fromBlock");
+    rewardsDistribution.commit(2, 1, recipients, workerAmounts, stakerAmounts);
+  }
+
   function test_RevertsIf_CommittingSameDataTwice() public {
     (uint256[] memory recipients, uint256[] memory workerAmounts, uint256[] memory stakerAmounts) = prepareRewards(1);
     vm.roll(10);


### PR DESCRIPTION
Fixes [carrot-08](https://github.com/said017/subsquid-audit/issues/17) and [carrot-01](https://github.com/said017/subsquid-audit/issues/3)

Technically carrot-08 is still possible, when doing commitment1 -> commitment2 -> commitment1, but it's not likely to happen