### PR TITLE
Remove worker from active worker list only on withdraw

### DIFF
--- a/packages/contracts/src/WorkerRegistration.sol
+++ b/packages/contracts/src/WorkerRegistration.sol
@@ -38,7 +38,7 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   IRouter public immutable router;
   mapping(uint256 => Worker) public workers;
   mapping(bytes peerId => uint256 id) public workerIds;
-  uint256[] public activeWorkerIds;
+  EnumerableSet.UintSet activeWorkerIds;
   mapping(address creator => EnumerableSet.UintSet) internal ownedWorkers;
 
   /**
@@ -83,7 +83,7 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
     });
 
     workerIds[peerId] = workerId;
-    activeWorkerIds.push(workerId);
+    activeWorkerIds.add(workerId);
     ownedWorkers[msg.sender].add(workerId);
 
     tSQD.transferFrom(msg.sender, address(this), _bondAmount);
@@ -123,13 +123,7 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
     require(worker.creator == msg.sender, "Not worker creator");
     require(block.number >= worker.deregisteredAt + lockPeriod(), "Worker is locked");
 
-    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
-      if (activeWorkerIds[i] == workerId) {
-        activeWorkerIds[i] = activeWorkerIds[activeWorkerIds.length - 1];
-        activeWorkerIds.pop();
-        break;
-      }
-    }
+    activeWorkerIds.remove(workerId);
 
     uint256 bond = worker.bond;
     delete workers[workerId];
@@ -175,10 +169,11 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   /// @dev Returns the list of active workers.
   function getActiveWorkers() external view returns (Worker[] memory) {
     Worker[] memory activeWorkers = new Worker[](getActiveWorkerCount());
+    uint256[] memory _activeWorkerIds = activeWorkerIds.values();
 
     uint256 activeIndex = 0;
-    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
-      uint256 workerId = activeWorkerIds[i];
+    for (uint256 i = 0; i < _activeWorkerIds.length; i++) {
+      uint256 workerId = _activeWorkerIds[i];
       Worker storage worker = workers[workerId];
       if (isWorkerActive(worker)) {
         activeWorkers[activeIndex] = worker;
@@ -192,10 +187,11 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   /// @dev Returns the list of active worker IDs.
   function getActiveWorkerIds() public view returns (uint256[] memory) {
     uint256[] memory activeWorkers = new uint256[](getActiveWorkerCount());
+    uint256[] memory _activeWorkerIds = activeWorkerIds.values();
 
     uint256 activeIndex = 0;
-    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
-      uint256 workerId = activeWorkerIds[i];
+    for (uint256 i = 0; i < _activeWorkerIds.length; i++) {
+      uint256 workerId = _activeWorkerIds[i];
       Worker storage worker = workers[workerId];
       if (isWorkerActive(worker)) {
         activeWorkers[activeIndex] = workerId;
@@ -217,8 +213,9 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   /// @notice Worker is considered active if it has been registered and not deregistered yet
   function getActiveWorkerCount() public view returns (uint256) {
     uint256 activeCount = 0;
-    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
-      uint256 workerId = activeWorkerIds[i];
+    uint256[] memory _activeWorkerIds = activeWorkerIds.values();
+    for (uint256 i = 0; i < _activeWorkerIds.length; i++) {
+      uint256 workerId = _activeWorkerIds[i];
       Worker storage worker = workers[workerId];
       if (isWorkerActive(worker)) {
         activeCount++;
@@ -228,11 +225,9 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   }
 
   /// @dev Get worker by index
-  /// @param index Index of the worker
+  /// @param workerId ID of the worker
   /// @return Worker under the index
-  function getWorkerByIndex(uint256 index) external view returns (Worker memory) {
-    require(index < activeWorkerIds.length, "Index out of bounds");
-    uint256 workerId = activeWorkerIds[index];
+  function getWorker(uint256 workerId) external view returns (Worker memory) {
     return workers[workerId];
   }
 
@@ -243,7 +238,7 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
 
   /// @dev get count of all workers
   function getAllWorkersCount() external view returns (uint256) {
-    return activeWorkerIds.length;
+    return activeWorkerIds.length();
   }
 
   function getMetadata(bytes calldata peerId) external view returns (string memory) {

--- a/packages/contracts/src/WorkerRegistration.sol
+++ b/packages/contracts/src/WorkerRegistration.sol
@@ -105,14 +105,6 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
 
     workers[workerId].deregisteredAt = nextEpoch();
 
-    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
-      if (activeWorkerIds[i] == workerId) {
-        activeWorkerIds[i] = activeWorkerIds[activeWorkerIds.length - 1];
-        activeWorkerIds.pop();
-        break;
-      }
-    }
-
     emit WorkerDeregistered(workerId, msg.sender, workers[workerId].deregisteredAt);
   }
 
@@ -130,6 +122,14 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
     require(!isWorkerActive(worker), "Worker is active");
     require(worker.creator == msg.sender, "Not worker creator");
     require(block.number >= worker.deregisteredAt + lockPeriod(), "Worker is locked");
+
+    for (uint256 i = 0; i < activeWorkerIds.length; i++) {
+      if (activeWorkerIds[i] == workerId) {
+        activeWorkerIds[i] = activeWorkerIds[activeWorkerIds.length - 1];
+        activeWorkerIds.pop();
+        break;
+      }
+    }
 
     uint256 bond = worker.bond;
     delete workers[workerId];
@@ -173,7 +173,7 @@ contract WorkerRegistration is AccessControlledPausable, IWorkerRegistration {
   }
 
   /// @dev Returns the list of active workers.
-  function getActiveWorkers() public view returns (Worker[] memory) {
+  function getActiveWorkers() external view returns (Worker[] memory) {
     Worker[] memory activeWorkers = new Worker[](getActiveWorkerCount());
 
     uint256 activeIndex = 0;

--- a/packages/contracts/test/WorkerRegistration/WorkerRegistration.register.t.sol
+++ b/packages/contracts/test/WorkerRegistration/WorkerRegistration.register.t.sol
@@ -42,7 +42,7 @@ contract WorkerRegistrationRegisterTest is WorkerRegistrationTest {
   function test_CorrectlyCreatesWorkerStruct() public {
     workerRegistration.register(workerId, "metadata");
 
-    WorkerRegistration.Worker memory workerStruct = workerRegistration.getWorkerByIndex(0);
+    WorkerRegistration.Worker memory workerStruct = workerRegistration.getWorker(1);
     assertEq(workerStruct.creator, creator);
     assertEq(workerStruct.peerId, workerId);
     assertEq(workerStruct.bond, workerRegistration.bondAmount());

--- a/packages/contracts/test/WorkerRegistration/WorkerRegistration.withdraw.t.sol
+++ b/packages/contracts/test/WorkerRegistration/WorkerRegistration.withdraw.t.sol
@@ -98,4 +98,28 @@ contract WorkerRegistrationWithdrawTest is WorkerRegistrationTest {
     emit WorkerWithdrawn(1, creator);
     workerRegistration.withdraw(workerId);
   }
+
+  function testRemovesLastWorkerIdFromActiveWorkerIds() public {
+    workerRegistration.register(workerId);
+    jumpEpoch();
+    workerRegistration.deregister(workerId);
+    jumpEpoch();
+    jumpEpoch();
+    workerRegistration.withdraw(workerId);
+    assertEq(workerRegistration.getAllWorkersCount(), 0);
+  }
+
+  function testRemovesNotLastWorkerIdFromActiveWorkerIds() public {
+    token.approve(address(workerRegistration), workerRegistration.bondAmount() * 2);
+
+    workerRegistration.register(workerId);
+    workerRegistration.register(workerId2);
+    jumpEpoch();
+    workerRegistration.deregister(workerId);
+    jumpEpoch();
+    jumpEpoch();
+    workerRegistration.withdraw(workerId);
+    assertEq(workerRegistration.getAllWorkersCount(), 1);
+    assertEq(workerRegistration.getWorkerByIndex(0).peerId, workerId2);
+  }
 }

--- a/packages/contracts/test/WorkerRegistration/WorkerRegistration.withdraw.t.sol
+++ b/packages/contracts/test/WorkerRegistration/WorkerRegistration.withdraw.t.sol
@@ -120,6 +120,6 @@ contract WorkerRegistrationWithdrawTest is WorkerRegistrationTest {
     jumpEpoch();
     workerRegistration.withdraw(workerId);
     assertEq(workerRegistration.getAllWorkersCount(), 1);
-    assertEq(workerRegistration.getWorkerByIndex(0).peerId, workerId2);
+    assertEq(workerRegistration.getActiveWorkers()[0].peerId, workerId2);
   }
 }


### PR DESCRIPTION
Fixes [carrot-03](https://github.com/said017/subsquid-audit/issues/6)
Fixes [carrot-02](https://github.com/said017/subsquid-audit/issues/8),  by removing iterations from all state-changing functions. `activeWorkerIds` get iterated over only in view functions now