### PR TITLE
Add deposited funds into vesting schedule

### DIFF
--- a/packages/contracts/src/Executable.sol
+++ b/packages/contracts/src/Executable.sol
@@ -10,6 +10,7 @@ abstract contract Executable {
 
   IERC20 public tSQD;
   IRouter public router;
+  uint256 public depositedIntoProtocol;
 
   function _canExecute(address executor) internal view virtual returns (bool);
 
@@ -28,6 +29,14 @@ abstract contract Executable {
     if (requiredApprove > 0) {
       tSQD.approve(to, requiredApprove);
     }
-    return to.functionCall(data);
+    depositedIntoProtocol += tSQD.balanceOf(address(this));
+    bytes memory result = to.functionCall(data);
+    uint256 balanceAfter = tSQD.balanceOf(address(this));
+    if (balanceAfter > depositedIntoProtocol) {
+      depositedIntoProtocol = 0;
+    } else {
+      depositedIntoProtocol -= balanceAfter;
+    }
+    return result;
   }
 }

--- a/packages/contracts/src/Vesting.sol
+++ b/packages/contracts/src/Vesting.sol
@@ -49,10 +49,19 @@ contract SubsquidVesting is Executable, VestingWallet {
     super.release(token);
   }
 
+  function releasable(address token) public view override returns (uint256) {
+    uint256 _releasable = super.releasable(token);
+    uint256 currentBalance = balanceOf(IERC20(token));
+    if (currentBalance < _releasable) {
+      return currentBalance;
+    }
+    return _releasable;
+  }
+
   function _vestingSchedule(uint256 totalAllocation, uint64 timestamp) internal view virtual override returns (uint256) {
     if (timestamp < start()) return 0;
     uint256 cliff = totalAllocation * immediateReleaseBIP / 10000;
-    return cliff + super._vestingSchedule(totalAllocation - cliff, timestamp);
+    return cliff + super._vestingSchedule(totalAllocation - cliff + depositedIntoProtocol, timestamp);
   }
 
   function _canExecute(address executor) internal view override returns (bool) {


### PR DESCRIPTION
Fixes [carrot-07](https://github.com/said017/subsquid-audit/issues/18)

This solution assumes that any token deposit than goes into protocol through vesting execution, can only return to vesting through execution. If it would be possible to do differently, this would mess with vesting schedule, but also it would not make sence to transfer these tokens into vesting, since they would be already unlocked