### PR TITLE
Add Solana SQD SPL token package, mint CLI, and tests

### DIFF
--- a/packages/solana-sqd-token/README.md
+++ b/packages/solana-sqd-token/README.md
@@ -1,0 +1,62 @@
+# SQD Solana Token
+
+This package mirrors the fixed-supply `SQD` ERC-20 token on Solana as a standard SPL mint.
+
+## What was ported from the EVM contracts
+
+The existing EVM token in [packages/contracts/src/SQD.sol](/Users/gradonsky/SQD/sqd-migration/subsquid-network-contracts/packages/contracts/src/SQD.sol:1) has a few important properties:
+
+- Name: `SQD Token`
+- Symbol: `SQD`
+- Decimals: `18`
+- Fixed initial supply: `1,337,000,000 SQD`
+- No ongoing mint schedule in the token contract itself
+
+The broader EVM system uses that token in staking, worker bonding, rewards, vesting, and gateway staking. Those protocol contracts are EVM-specific and are not reimplemented here. This Solana package focuses on the token primitive itself.
+
+## Important Solana constraint
+
+Standard SPL token balances are stored as `u64`. That means the EVM base-unit supply of:
+
+`1,337,000,000 * 10^18 = 1,337,000,000,000,000,000,000,000,000`
+
+cannot fit into an SPL mint.
+
+To keep the same whole-token supply on Solana while staying within SPL limits, this package uses:
+
+- Solana decimals: `10`
+- Whole-token supply: `1,337,000,000 SQD`
+- Solana base-unit supply: `13,370,000,000,000,000,000`
+
+`10` is the maximum decimal precision that still fits `1,337,000,000 SQD` into the SPL `u64` amount model.
+
+## Solana design
+
+On Solana, the equivalent primitive is a standard SPL mint rather than a custom token program. The CLI in this folder:
+
+1. Creates a mint with `10` decimals.
+2. Creates the recipient's associated token account.
+3. Mints the full fixed SQD supply once.
+4. Revokes mint authority and freeze authority.
+
+That gives us the same fixed-supply whole-token behavior as the current ERC-20 token deployment, within SPL's amount limits.
+
+## Scripts
+
+```bash
+pnpm --filter @subsquid-network/solana-sqd-token create:mint -- --rpc-url http://127.0.0.1:8899
+pnpm --filter @subsquid-network/solana-sqd-token test
+```
+
+CLI options:
+
+- `--rpc-url`: Solana RPC endpoint. Defaults to `http://127.0.0.1:8899`.
+- `--keypair`: fee payer keypair path. Defaults to `~/.config/solana/id.json`.
+- `--recipient`: recipient public key. Defaults to the fee payer.
+- `--mint-keypair`: optional mint keypair file. If the file does not exist, it will be generated and saved.
+
+## Notes
+
+- Tests run against `solana-bankrun`, so they do not require `solana-test-validator`.
+- This package does not attach Metaplex metadata yet. Standard SPL tokens do not store `name` and `symbol` in the mint account itself.
+- The Arbitrum bridge helper from the EVM token is intentionally not ported, because Solana bridging requires a different bridge stack.

--- a/packages/solana-sqd-token/package.json
+++ b/packages/solana-sqd-token/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@subsquid-network/solana-sqd-token",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit -p tsconfig.json",
+    "create:mint": "tsx src/cli/create-sqd-mint.ts",
+    "test": "tsx --test --test-concurrency=1 test/**/*.test.ts"
+  },
+  "dependencies": {
+    "@solana/spl-token": "^0.4.14",
+    "@solana/web3.js": "^1.98.4"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "solana-bankrun": "^0.4.0",
+    "spl-token-bankrun": "^0.2.6",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/packages/solana-sqd-token/src/cli/create-sqd-mint.ts
+++ b/packages/solana-sqd-token/src/cli/create-sqd-mint.ts
@@ -1,0 +1,111 @@
+import { existsSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+
+import {
+  EVM_SQD_TOKEN_DECIMALS,
+  EVM_SQD_TOTAL_SUPPLY,
+  SQD_TOKEN_DECIMALS,
+  SQD_TOKEN_NAME,
+  SQD_TOKEN_SYMBOL,
+  SQD_TOTAL_SUPPLY
+} from "../constants.js";
+import { loadKeypairFromFile, loadOrCreateKeypair, resolvePath } from "../keypair.js";
+import { createSqdMint, fetchSqdMint } from "../sqdMint.js";
+
+const DEFAULT_RPC_URL = "http://127.0.0.1:8899";
+const DEFAULT_KEYPAIR_PATH = "~/.config/solana/id.json";
+
+function printUsage() {
+  console.log(`Usage:
+  pnpm --filter @subsquid-network/solana-sqd-token create:mint -- [options]
+
+Options:
+  --rpc-url <url>         Solana RPC endpoint (default: ${DEFAULT_RPC_URL})
+  --keypair <path>        Fee payer keypair path (default: ${DEFAULT_KEYPAIR_PATH})
+  --recipient <pubkey>    Recipient of the full SQD supply (default: fee payer)
+  --mint-keypair <path>   Optional mint keypair file; creates one if missing
+  --help                  Show this message
+`);
+}
+
+async function main() {
+  const { values } = parseArgs({
+    allowPositionals: false,
+    options: {
+      "rpc-url": { type: "string", default: DEFAULT_RPC_URL },
+      keypair: { type: "string", default: DEFAULT_KEYPAIR_PATH },
+      recipient: { type: "string" },
+      "mint-keypair": { type: "string" },
+      help: { type: "boolean", default: false }
+    }
+  });
+
+  if (values.help) {
+    printUsage();
+    return;
+  }
+
+  const connection = new Connection(values["rpc-url"], "confirmed");
+  const payer = loadKeypairFromFile(values.keypair);
+  const recipient = values.recipient ? new PublicKey(values.recipient) : payer.publicKey;
+
+  let mintKeypair: Keypair | undefined;
+  let mintKeypairPath: string | undefined;
+  let mintKeypairCreated = false;
+
+  if (values["mint-keypair"]) {
+    const targetPath = resolvePath(values["mint-keypair"]);
+    mintKeypairPath = targetPath;
+    if (existsSync(targetPath)) {
+      mintKeypair = loadKeypairFromFile(targetPath);
+    } else {
+      const created = loadOrCreateKeypair(targetPath);
+      mintKeypair = created.keypair;
+      mintKeypairCreated = created.created;
+    }
+  } else {
+    mintKeypair = Keypair.generate();
+  }
+
+  const result = await createSqdMint({
+    connection,
+    payer,
+    recipient,
+    mintKeypair
+  });
+  const mintState = await fetchSqdMint(connection, result.mintAddress);
+
+  console.log(
+    JSON.stringify(
+      {
+        token: {
+          name: SQD_TOKEN_NAME,
+          symbol: SQD_TOKEN_SYMBOL,
+          decimals: SQD_TOKEN_DECIMALS,
+          totalSupply: SQD_TOTAL_SUPPLY.toString(),
+          evmDecimals: EVM_SQD_TOKEN_DECIMALS,
+          evmTotalSupply: EVM_SQD_TOTAL_SUPPLY.toString()
+        },
+        cluster: values["rpc-url"],
+        payer: payer.publicKey.toBase58(),
+        recipient: result.recipientAddress.toBase58(),
+        mintAddress: result.mintAddress.toBase58(),
+        recipientAtaAddress: result.recipientAtaAddress.toBase58(),
+        signature: result.signature,
+        mintAuthorityRevoked: mintState.mintAuthority === null,
+        freezeAuthorityRevoked: mintState.freezeAuthority === null,
+        mintKeypairPath,
+        mintKeypairCreated
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/solana-sqd-token/src/constants.ts
+++ b/packages/solana-sqd-token/src/constants.ts
@@ -1,0 +1,13 @@
+export const SQD_TOKEN_NAME = "SQD Token";
+export const SQD_TOKEN_SYMBOL = "SQD";
+export const SQD_WHOLE_SUPPLY = 1_337_000_000n;
+export const EVM_SQD_TOKEN_DECIMALS = 18;
+export const SOLANA_U64_MAX = 2n ** 64n - 1n;
+export const MAX_SOLANA_DECIMALS_FOR_SQD_SUPPLY = 10;
+export const SQD_TOKEN_DECIMALS = MAX_SOLANA_DECIMALS_FOR_SQD_SUPPLY;
+export const SQD_TOTAL_SUPPLY = SQD_WHOLE_SUPPLY * 10n ** BigInt(SQD_TOKEN_DECIMALS);
+export const EVM_SQD_TOTAL_SUPPLY = SQD_WHOLE_SUPPLY * 10n ** BigInt(EVM_SQD_TOKEN_DECIMALS);
+
+if (SQD_TOTAL_SUPPLY > SOLANA_U64_MAX) {
+  throw new Error("SQD total supply exceeds the SPL Token u64 limit");
+}

--- a/packages/solana-sqd-token/src/keypair.ts
+++ b/packages/solana-sqd-token/src/keypair.ts
@@ -1,0 +1,34 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { Keypair } from "@solana/web3.js";
+
+function expandHome(inputPath: string): string {
+  if (inputPath === "~") return os.homedir();
+  if (inputPath.startsWith("~/")) return path.join(os.homedir(), inputPath.slice(2));
+  return inputPath;
+}
+
+export function resolvePath(inputPath: string): string {
+  return path.resolve(expandHome(inputPath));
+}
+
+export function loadKeypairFromFile(filePath: string): Keypair {
+  const absolutePath = resolvePath(filePath);
+  const contents = readFileSync(absolutePath, "utf8");
+  const secretKey = Uint8Array.from(JSON.parse(contents) as number[]);
+  return Keypair.fromSecretKey(secretKey);
+}
+
+export function loadOrCreateKeypair(filePath: string): { keypair: Keypair; filePath: string; created: boolean } {
+  const absolutePath = resolvePath(filePath);
+  if (existsSync(absolutePath)) {
+    return { keypair: loadKeypairFromFile(absolutePath), filePath: absolutePath, created: false };
+  }
+
+  const keypair = Keypair.generate();
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, JSON.stringify(Array.from(keypair.secretKey)));
+  return { keypair, filePath: absolutePath, created: true };
+}

--- a/packages/solana-sqd-token/src/sqdMint.ts
+++ b/packages/solana-sqd-token/src/sqdMint.ts
@@ -1,0 +1,117 @@
+import {
+  AuthorityType,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountInstruction,
+  createInitializeMintInstruction,
+  createMintToInstruction,
+  createSetAuthorityInstruction,
+  getAssociatedTokenAddressSync,
+  getMinimumBalanceForRentExemptMint,
+  getMint
+} from "@solana/spl-token";
+import {
+  Connection,
+  type ConfirmOptions,
+  type Keypair,
+  PublicKey,
+  type TransactionInstruction,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+
+import { SQD_TOKEN_DECIMALS, SQD_TOTAL_SUPPLY } from "./constants.js";
+
+export interface CreateSqdMintParams {
+  connection: Connection;
+  payer: Keypair;
+  recipient?: PublicKey;
+  mintKeypair?: Keypair;
+  confirmOptions?: ConfirmOptions;
+}
+
+export interface CreateSqdMintResult {
+  mintAddress: PublicKey;
+  recipientAddress: PublicKey;
+  recipientAtaAddress: PublicKey;
+  signature: string;
+}
+
+export interface BuildCreateSqdMintInstructionsParams {
+  payerAddress: PublicKey;
+  mintAddress: PublicKey;
+  recipientAddress: PublicKey;
+  mintAuthorityAddress?: PublicKey;
+  lamportsForMint: number;
+}
+
+export interface BuildCreateSqdMintInstructionsResult {
+  recipientAtaAddress: PublicKey;
+  instructions: TransactionInstruction[];
+}
+
+export function buildCreateSqdMintInstructions({
+  payerAddress,
+  mintAddress,
+  recipientAddress,
+  mintAuthorityAddress = payerAddress,
+  lamportsForMint
+}: BuildCreateSqdMintInstructionsParams): BuildCreateSqdMintInstructionsResult {
+  const recipientAtaAddress = getAssociatedTokenAddressSync(mintAddress, recipientAddress);
+
+  return {
+    recipientAtaAddress,
+    instructions: [
+      SystemProgram.createAccount({
+        fromPubkey: payerAddress,
+        newAccountPubkey: mintAddress,
+        space: MINT_SIZE,
+        lamports: lamportsForMint,
+        programId: TOKEN_PROGRAM_ID
+      }),
+      createInitializeMintInstruction(mintAddress, SQD_TOKEN_DECIMALS, mintAuthorityAddress, mintAuthorityAddress),
+      createAssociatedTokenAccountInstruction(payerAddress, recipientAtaAddress, recipientAddress, mintAddress),
+      createMintToInstruction(mintAddress, recipientAtaAddress, mintAuthorityAddress, SQD_TOTAL_SUPPLY),
+      createSetAuthorityInstruction(mintAddress, mintAuthorityAddress, AuthorityType.MintTokens, null),
+      createSetAuthorityInstruction(mintAddress, mintAuthorityAddress, AuthorityType.FreezeAccount, null)
+    ]
+  };
+}
+
+export async function createSqdMint({
+  connection,
+  payer,
+  recipient = payer.publicKey,
+  mintKeypair,
+  confirmOptions
+}: CreateSqdMintParams): Promise<CreateSqdMintResult> {
+  const mint = mintKeypair ?? payer;
+  const mintAddress = mint.publicKey;
+  const lamports = await getMinimumBalanceForRentExemptMint(connection);
+  const { instructions, recipientAtaAddress } = buildCreateSqdMintInstructions({
+    payerAddress: payer.publicKey,
+    mintAddress,
+    recipientAddress: recipient,
+    mintAuthorityAddress: payer.publicKey,
+    lamportsForMint: lamports
+  });
+  const transaction = new Transaction().add(...instructions);
+
+  const signers = mint === payer ? [payer] : [payer, mint];
+  const signature = await sendAndConfirmTransaction(connection, transaction, signers, {
+    commitment: "confirmed",
+    ...confirmOptions
+  });
+
+  return {
+    mintAddress,
+    recipientAddress: recipient,
+    recipientAtaAddress,
+    signature
+  };
+}
+
+export async function fetchSqdMint(connection: Connection, mintAddress: PublicKey) {
+  return getMint(connection, mintAddress, "confirmed", TOKEN_PROGRAM_ID);
+}

--- a/packages/solana-sqd-token/src/types/spl-token-bankrun.d.ts
+++ b/packages/solana-sqd-token/src/types/spl-token-bankrun.d.ts
@@ -1,0 +1,25 @@
+declare module "spl-token-bankrun" {
+  import type { Account, Mint } from "@solana/spl-token";
+  import type { Keypair, PublicKey, Signer } from "@solana/web3.js";
+  import type { BanksClient, BanksTransactionMeta } from "solana-bankrun";
+
+  export function createAssociatedTokenAccount(
+    banksClient: BanksClient,
+    payer: Signer,
+    mint: PublicKey,
+    owner: PublicKey
+  ): Promise<PublicKey>;
+
+  export function getAccount(banksClient: BanksClient, address: PublicKey): Promise<Account>;
+
+  export function getMint(banksClient: BanksClient, address: PublicKey): Promise<Mint>;
+
+  export function transfer(
+    banksClient: BanksClient,
+    payer: Signer,
+    source: PublicKey,
+    destination: PublicKey,
+    owner: PublicKey | Keypair | Signer,
+    amount: number | bigint
+  ): Promise<BanksTransactionMeta>;
+}

--- a/packages/solana-sqd-token/test/sqd-token.test.ts
+++ b/packages/solana-sqd-token/test/sqd-token.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MINT_SIZE } from "@solana/spl-token";
+import { Keypair, Transaction } from "@solana/web3.js";
+import { start } from "solana-bankrun";
+import { createAssociatedTokenAccount, getAccount, getMint, transfer } from "spl-token-bankrun";
+
+import {
+  EVM_SQD_TOKEN_DECIMALS,
+  EVM_SQD_TOTAL_SUPPLY,
+  MAX_SOLANA_DECIMALS_FOR_SQD_SUPPLY,
+  SOLANA_U64_MAX,
+  SQD_TOKEN_DECIMALS,
+  SQD_TOKEN_NAME,
+  SQD_TOKEN_SYMBOL,
+  SQD_TOTAL_SUPPLY,
+  SQD_WHOLE_SUPPLY
+} from "../src/constants.js";
+import { buildCreateSqdMintInstructions } from "../src/sqdMint.js";
+
+test("SQD Solana constants preserve whole-token supply within SPL limits", () => {
+  assert.equal(SQD_TOKEN_NAME, "SQD Token");
+  assert.equal(SQD_TOKEN_SYMBOL, "SQD");
+  assert.equal(EVM_SQD_TOKEN_DECIMALS, 18);
+  assert.equal(MAX_SOLANA_DECIMALS_FOR_SQD_SUPPLY, 10);
+  assert.equal(SQD_TOKEN_DECIMALS, 10);
+  assert.equal(SQD_WHOLE_SUPPLY, 1_337_000_000n);
+  assert.equal(EVM_SQD_TOTAL_SUPPLY, 1_337_000_000n * 10n ** 18n);
+  assert.equal(SQD_TOTAL_SUPPLY, 1_337_000_000n * 10n ** 10n);
+  assert.equal(SQD_TOTAL_SUPPLY <= SOLANA_U64_MAX, true);
+});
+
+test("creates a fixed-supply SQD SPL token and allows transfers", async () => {
+  const context = await start([], []);
+  const banksClient = context.banksClient;
+  const payer = context.payer;
+  const recipient = Keypair.generate();
+  const receiver = Keypair.generate();
+  const mintKeypair = Keypair.generate();
+  const rent = await banksClient.getRent();
+
+  const { instructions, recipientAtaAddress } = buildCreateSqdMintInstructions({
+    payerAddress: payer.publicKey,
+    mintAddress: mintKeypair.publicKey,
+    recipientAddress: recipient.publicKey,
+    mintAuthorityAddress: payer.publicKey,
+    lamportsForMint: Number(await rent.minimumBalance(BigInt(MINT_SIZE)))
+  });
+  const createMintTx = new Transaction();
+  const [mintBlockhash] = (await banksClient.getLatestBlockhash()) ?? [];
+  createMintTx.recentBlockhash = mintBlockhash;
+  createMintTx.feePayer = payer.publicKey;
+  createMintTx.add(...instructions);
+  createMintTx.sign(payer, mintKeypair);
+  await banksClient.processTransaction(createMintTx);
+
+  const mint = await getMint(banksClient, mintKeypair.publicKey);
+  assert.equal(mint.address.toBase58(), mintKeypair.publicKey.toBase58());
+  assert.equal(mint.decimals, SQD_TOKEN_DECIMALS);
+  assert.equal(mint.supply, SQD_TOTAL_SUPPLY);
+  assert.equal(mint.mintAuthority, null);
+  assert.equal(mint.freezeAuthority, null);
+
+  const recipientAccount = await getAccount(banksClient, recipientAtaAddress);
+  assert.equal(recipientAccount.amount, SQD_TOTAL_SUPPLY);
+
+  const receiverAta = await createAssociatedTokenAccount(
+    banksClient,
+    payer,
+    mintKeypair.publicKey,
+    receiver.publicKey
+  );
+
+  const transferAmount = 25n * 10n ** BigInt(SQD_TOKEN_DECIMALS);
+  await transfer(banksClient, payer, recipientAtaAddress, receiverAta, recipient, transferAmount);
+
+  const updatedRecipientAccount = await getAccount(banksClient, recipientAtaAddress);
+  const updatedReceiverAccount = await getAccount(banksClient, receiverAta);
+
+  assert.equal(updatedRecipientAccount.amount, SQD_TOTAL_SUPPLY - transferAmount);
+  assert.equal(updatedReceiverAccount.amount, transferAmount);
+});

--- a/packages/solana-sqd-token/tsconfig.json
+++ b/packages/solana-sqd-token/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Important note

The EVM SQD token uses 18 decimals, but a standard SPL token stores amounts as `u64`.
Because of that, `1,337,000,000 * 10^18` does not fit in a standard SPL mint.

This implementation keeps the same whole-token supply (`1,337,000,000 SQD`) but uses `10` decimals on Solana, which is the maximum precision that fits SPL limits.
