### PR TITLE
balance-monitor: add portal metrics

### DIFF
--- a/packages/balance-monitor/.gitignore
+++ b/packages/balance-monitor/.gitignore
@@ -6,3 +6,4 @@ pings.csv
 queries.csv
 stakes.csv
 *.pem
+dist/

--- a/packages/balance-monitor/src/client.ts
+++ b/packages/balance-monitor/src/client.ts
@@ -1,0 +1,17 @@
+import { createPublicClient, http } from "viem";
+import { arbitrum, arbitrumSepolia } from "viem/chains";
+
+if (!process.env.RPC_URL) {
+  throw new Error("RPC_URL is not set");
+}
+
+export const chainId = await createPublicClient({
+  transport: http(process.env.RPC_URL),
+}).getChainId();
+
+const chain = chainId === arbitrum.id ? arbitrum : arbitrumSepolia;
+
+export const client = createPublicClient({
+  chain,
+  transport: http(process.env.RPC_URL),
+});

--- a/packages/balance-monitor/src/index.ts
+++ b/packages/balance-monitor/src/index.ts
@@ -1,115 +1,21 @@
-import { createPublicClient, formatEther, http, parseAbi } from "viem";
-import { arbitrum, arbitrumSepolia } from "viem/chains";
-import express from "express";
-import promClient from "prom-client";
+import { startServer } from "./server.js";
+import { hasWalletsToMonitor, updateWalletMetrics } from "./wallets.js";
+import { hasPortalToMonitor, updatePortalMetrics } from "./portal.js";
 
-if (!process.env.RPC_URL) {
-  throw new Error("RPC_URL is not set");
-}
-
-const ethBalanceWallets = (process.env.ETH_HOLDERS ?? "")
-  .split(",")
-  .map((address) => address.trim())
-  .filter((address) => address);
-
-const sqdBalanceWallets = (process.env.SQD_HOLDERS ?? "")
-  .split(",")
-  .map((address) => address.trim())
-  .filter((address) => address);
-
-if (ethBalanceWallets.length + sqdBalanceWallets.length === 0) {
-  throw new Error("No wallets to monitor. Set ETH_HOLDERS and SQD_HOLDERS");
-}
-
-const chainId = await createPublicClient({
-  transport: http(process.env.RPC_URL),
-}).getChainId();
-const chain = chainId === arbitrum.id ? arbitrum : arbitrumSepolia;
-
-const client = createPublicClient({
-  chain,
-  transport: http(process.env.RPC_URL),
-});
-
-const multicallAbi = parseAbi([
-  "function getEthBalance(address) view returns (uint256)",
-]);
-const tokenAbi = parseAbi([
-  "function balanceOf(address) view returns (uint256)",
-]);
-
-const tokenAddress =
-  chainId === arbitrum.id
-    ? "0x1337420dED5ADb9980CFc35f8f2B054ea86f8aB1"
-    : "0x24f9C46d86c064a6FA2a568F918fe62fC6917B3c";
-
-const ethMulticalls = ethBalanceWallets.map(
-  (address) =>
-    ({
-      address: client.chain.contracts.multicall3.address,
-      abi: multicallAbi,
-      functionName: "getEthBalance",
-      args: [address],
-    }) as const,
-);
-const tokenMulticalls = sqdBalanceWallets.map(
-  (address) =>
-    ({
-      address: tokenAddress,
-      abi: tokenAbi,
-      functionName: "balanceOf",
-      args: [address],
-    }) as const,
-);
-
-// start express server with /metrics endpoint
-const app = express();
-const port = process.env.PORT ?? 3000;
-
-app.get("/metrics", async (_, res) => {
-  res.set("Content-Type", promClient.register.contentType);
-  res.end(await promClient.register.metrics());
-});
-
-app.listen(port, () => {
-  console.log(`Server listening at ${port}`);
-});
-
-const balanceGauge = new promClient.Gauge({
-  name: "sqd_wallet_balance",
-  help: "Balance of the wallet",
-  labelNames: ["wallet", "token"],
-});
-
-const updateMetrics = async () => {
-  const balances =
-    (await client
-      .multicall({
-        contracts: [...ethMulticalls, ...tokenMulticalls],
-      })
-      .catch(console.error)) ?? [];
-  const timestamp = new Date().toISOString();
-  let i = 0;
-  for (const balance of balances) {
-    if (balance.status === "success") {
-      if (i < ethMulticalls.length) {
-        balanceGauge.set(
-          { wallet: ethBalanceWallets[i], token: "ETH" },
-          Number(formatEther(balance.result)),
-        );
-      } else {
-        balanceGauge.set(
-          { wallet: sqdBalanceWallets[i - ethMulticalls.length], token: "SQD" },
-          Number(formatEther(balance.result)),
-        );
-      }
-    }
-    i++;
-  }
-  setTimeout(
-    updateMetrics,
-    1000 * 60 * Number(process.env.INTERVAL_MINUTES ?? 120),
+if (!hasWalletsToMonitor && !hasPortalToMonitor) {
+  throw new Error(
+    "Nothing to monitor. Set ETH_HOLDERS, SQD_HOLDERS, or both PORTAL_REGISTRY and PORTAL_OPERATORS",
   );
-};
+}
+
+const intervalMs = 1000 * 60 * Number(process.env.INTERVAL_MINUTES ?? 120);
+
+startServer();
+
+async function updateMetrics() {
+  await updateWalletMetrics().catch(console.error);
+  await updatePortalMetrics().catch(console.error);
+  setTimeout(updateMetrics, intervalMs);
+}
 
 void updateMetrics();

--- a/packages/balance-monitor/src/index.ts
+++ b/packages/balance-monitor/src/index.ts
@@ -13,8 +13,10 @@ const intervalMs = 1000 * 60 * Number(process.env.INTERVAL_MINUTES ?? 120);
 startServer();
 
 async function updateMetrics() {
-  await updateWalletMetrics().catch(console.error);
-  await updatePortalMetrics().catch(console.error);
+  await Promise.all([
+    updateWalletMetrics().catch(console.error),
+    updatePortalMetrics().catch(console.error),
+  ]);
   setTimeout(updateMetrics, intervalMs);
 }
 

--- a/packages/balance-monitor/src/portal.ts
+++ b/packages/balance-monitor/src/portal.ts
@@ -1,0 +1,271 @@
+import {
+  formatUnits,
+  parseAbi,
+  zeroAddress,
+  type Address,
+} from "viem";
+import promClient from "prom-client";
+import { client } from "./client.js";
+
+const portalRegistryAddress = (process.env.PORTAL_REGISTRY ?? "").trim() as
+  | Address
+  | "";
+
+const portalOperators = (process.env.PORTAL_OPERATORS ?? "")
+  .split(",")
+  .map((a) => a.trim().toLowerCase())
+  .filter(Boolean);
+
+if (portalRegistryAddress && portalOperators.length === 0) {
+  throw new Error(
+    "PORTAL_REGISTRY is set but PORTAL_OPERATORS is empty. Set PORTAL_OPERATORS to a comma-separated list of operator addresses to monitor.",
+  );
+}
+if (!portalRegistryAddress && portalOperators.length > 0) {
+  throw new Error(
+    "PORTAL_OPERATORS is set but PORTAL_REGISTRY is empty. Set PORTAL_REGISTRY to the portal registry contract address.",
+  );
+}
+
+const portalOperatorSet = new Set(portalOperators);
+
+export const hasPortalToMonitor =
+  !!portalRegistryAddress && portalOperatorSet.size > 0;
+
+// Unix timestamp at end of year 9999, used as a cap when distribution is paused.
+const RUNWAY_INFINITY_CAP = 253402300799;
+
+const portalRegistryAbi = parseAbi([
+  "function clusterCount() view returns (uint256)",
+  "struct Portal { bytes peerId; string metadata; uint64 addedAt; }",
+  "struct Cluster { address clusterAddress; address operator; uint256 totalStaked; uint256 registeredAt; bool active; string metadata; Portal[] portals; }",
+  "function getClustersPaginated(uint256 offset, uint256 limit) view returns (bytes32[] clusterIds, Cluster[] clusters)",
+]);
+
+const portalPoolAbi = parseAbi([
+  "function getRunway() view returns (int256)",
+  "function getCurrentRewardBalance() view returns (int256)",
+  "function getRewardToken() view returns (address)",
+]);
+
+const tokenAbi = parseAbi([
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+  "function symbol() view returns (string)",
+]);
+
+const portalRunwayGauge = new promClient.Gauge({
+  name: "sqd_portal_runway_timestamp",
+  help: "Unix timestamp at which the portal pool runs out of reward credit. Capped at year 9999 when distribution is paused (rate=0 or no active stake).",
+  labelNames: ["portal", "operator", "active"],
+});
+
+const portalRewardBalanceGauge = new promClient.Gauge({
+  name: "sqd_portal_reward_balance",
+  help: "Portal pool reward token credit balance from getCurrentRewardBalance() (signed; negative means debt). Denominated in reward token units.",
+  labelNames: ["portal", "operator", "active", "reward_token", "reward_token_symbol"],
+});
+
+const portalRewardErc20BalanceGauge = new promClient.Gauge({
+  name: "sqd_portal_reward_erc20_balance",
+  help: "Portal pool raw ERC20 reward token balance (balanceOf the pool contract). Denominated in reward token units.",
+  labelNames: ["portal", "operator", "active", "reward_token", "reward_token_symbol"],
+});
+
+type Pool = {
+  address: Address;
+  operator: Address;
+  active: boolean;
+};
+
+type PoolData = {
+  pool: Pool;
+  runway?: bigint;
+  rewardBalance?: bigint;
+  rewardToken?: Address;
+  erc20Balance?: bigint;
+};
+
+type TokenMetadata = { decimals: number; symbol: string };
+const tokenMetadataCache = new Map<Address, TokenMetadata>();
+
+async function fetchPools(): Promise<Pool[]> {
+  const count = await client.readContract({
+    address: portalRegistryAddress as Address,
+    abi: portalRegistryAbi,
+    functionName: "clusterCount",
+  });
+  if (count === 0n) return [];
+
+  const [, clusters] = await client.readContract({
+    address: portalRegistryAddress as Address,
+    abi: portalRegistryAbi,
+    functionName: "getClustersPaginated",
+    args: [0n, count],
+  });
+
+  return clusters
+    .map(
+      (c): Pool => ({
+        address: c.clusterAddress,
+        operator: c.operator,
+        active: c.active,
+      }),
+    )
+    .filter(
+      (p) =>
+        p.address !== zeroAddress &&
+        portalOperatorSet.has(p.operator.toLowerCase()),
+    );
+}
+
+async function fetchPoolData(pools: Pool[]): Promise<PoolData[]> {
+  const calls = pools.flatMap(
+    (p) =>
+      [
+        {
+          address: p.address,
+          abi: portalPoolAbi,
+          functionName: "getRunway",
+        } as const,
+        {
+          address: p.address,
+          abi: portalPoolAbi,
+          functionName: "getCurrentRewardBalance",
+        } as const,
+        {
+          address: p.address,
+          abi: portalPoolAbi,
+          functionName: "getRewardToken",
+        } as const,
+      ] as const,
+  );
+  const results = await client.multicall({ contracts: calls });
+
+  return pools.map((pool, i) => {
+    const r = results[i * 3];
+    const b = results[i * 3 + 1];
+    const t = results[i * 3 + 2];
+    return {
+      pool,
+      runway: r.status === "success" ? (r.result as bigint) : undefined,
+      rewardBalance: b.status === "success" ? (b.result as bigint) : undefined,
+      rewardToken: t.status === "success" ? (t.result as Address) : undefined,
+    };
+  });
+}
+
+async function loadTokenMetadata(tokens: Address[]) {
+  const missing = tokens.filter((t) => !tokenMetadataCache.has(t));
+  if (missing.length === 0) return;
+
+  const calls = missing.flatMap(
+    (address) =>
+      [
+        { address, abi: tokenAbi, functionName: "decimals" } as const,
+        { address, abi: tokenAbi, functionName: "symbol" } as const,
+      ] as const,
+  );
+  const results = await client.multicall({ contracts: calls });
+  for (let i = 0; i < missing.length; i++) {
+    const decimalsRes = results[i * 2];
+    const symbolRes = results[i * 2 + 1];
+    if (decimalsRes.status === "success" && symbolRes.status === "success") {
+      tokenMetadataCache.set(missing[i], {
+        decimals: Number(decimalsRes.result),
+        symbol: String(symbolRes.result),
+      });
+    }
+  }
+}
+
+async function fetchErc20Balances(poolData: PoolData[]) {
+  const indexed = poolData
+    .map((p, idx) => ({ idx, p }))
+    .filter(({ p }) => !!p.rewardToken);
+  if (indexed.length === 0) return;
+
+  const calls = indexed.map(
+    ({ p }) =>
+      ({
+        address: p.rewardToken!,
+        abi: tokenAbi,
+        functionName: "balanceOf",
+        args: [p.pool.address],
+      }) as const,
+  );
+  const results = await client.multicall({ contracts: calls });
+  for (let i = 0; i < indexed.length; i++) {
+    const res = results[i];
+    if (res.status === "success") {
+      poolData[indexed[i].idx].erc20Balance = res.result;
+    }
+  }
+}
+
+function setGauges(poolData: PoolData[]) {
+  for (const { pool, runway, rewardBalance, rewardToken, erc20Balance } of poolData) {
+    const labels = {
+      portal: pool.address.toLowerCase(),
+      operator: pool.operator.toLowerCase(),
+      active: pool.active ? "true" : "false",
+    };
+
+    if (runway !== undefined) {
+      let runwaySeconds: number;
+      if (runway < 0n) {
+        // Should not occur on a healthy pool; surface as 0 to make dashboards visible.
+        runwaySeconds = 0;
+      } else if (runway > BigInt(RUNWAY_INFINITY_CAP)) {
+        runwaySeconds = RUNWAY_INFINITY_CAP;
+      } else {
+        runwaySeconds = Number(runway);
+      }
+      portalRunwayGauge.set(labels, runwaySeconds);
+    }
+
+    if (!rewardToken) continue;
+    const meta = tokenMetadataCache.get(rewardToken);
+    const decimals = meta?.decimals ?? 18;
+    const symbol = meta?.symbol ?? "UNKNOWN";
+    const tokenLabels = {
+      ...labels,
+      reward_token: rewardToken.toLowerCase(),
+      reward_token_symbol: symbol,
+    };
+
+    if (rewardBalance !== undefined) {
+      const sign = rewardBalance < 0n ? -1 : 1;
+      const abs = rewardBalance < 0n ? -rewardBalance : rewardBalance;
+      portalRewardBalanceGauge.set(
+        tokenLabels,
+        sign * Number(formatUnits(abs, decimals)),
+      );
+    }
+
+    if (erc20Balance !== undefined) {
+      portalRewardErc20BalanceGauge.set(
+        tokenLabels,
+        Number(formatUnits(erc20Balance, decimals)),
+      );
+    }
+  }
+}
+
+export async function updatePortalMetrics() {
+  if (!hasPortalToMonitor) return;
+
+  const pools = await fetchPools();
+  if (pools.length === 0) return;
+
+  const poolData = await fetchPoolData(pools);
+
+  const uniqueTokens = Array.from(
+    new Set(poolData.map((p) => p.rewardToken).filter((t): t is Address => !!t)),
+  );
+  await loadTokenMetadata(uniqueTokens);
+
+  await fetchErc20Balances(poolData);
+
+  setGauges(poolData);
+}

--- a/packages/balance-monitor/src/portal.ts
+++ b/packages/balance-monitor/src/portal.ts
@@ -1,5 +1,6 @@
 import {
   formatUnits,
+  getAddress,
   parseAbi,
   zeroAddress,
   type Address,
@@ -7,33 +8,33 @@ import {
 import promClient from "prom-client";
 import { client } from "./client.js";
 
-const portalRegistryAddress = (process.env.PORTAL_REGISTRY ?? "").trim() as
-  | Address
-  | "";
-
-const portalOperators = (process.env.PORTAL_OPERATORS ?? "")
+const rawRegistry = (process.env.PORTAL_REGISTRY ?? "").trim();
+const rawOperators = (process.env.PORTAL_OPERATORS ?? "")
   .split(",")
-  .map((a) => a.trim().toLowerCase())
+  .map((a) => a.trim())
   .filter(Boolean);
 
-if (portalRegistryAddress && portalOperators.length === 0) {
+if (rawRegistry && rawOperators.length === 0) {
   throw new Error(
     "PORTAL_REGISTRY is set but PORTAL_OPERATORS is empty. Set PORTAL_OPERATORS to a comma-separated list of operator addresses to monitor.",
   );
 }
-if (!portalRegistryAddress && portalOperators.length > 0) {
+if (!rawRegistry && rawOperators.length > 0) {
   throw new Error(
     "PORTAL_OPERATORS is set but PORTAL_REGISTRY is empty. Set PORTAL_REGISTRY to the portal registry contract address.",
   );
 }
 
-const portalOperatorSet = new Set(portalOperators);
+const portalRegistryAddress: Address | undefined = rawRegistry
+  ? getAddress(rawRegistry)
+  : undefined;
+const portalOperatorSet = new Set(rawOperators.map((a) => getAddress(a).toLowerCase()));
 
 export const hasPortalToMonitor =
   !!portalRegistryAddress && portalOperatorSet.size > 0;
 
 // Unix timestamp at end of year 9999, used as a cap when distribution is paused.
-const RUNWAY_INFINITY_CAP = 253402300799;
+const RUNWAY_INFINITY_CAP = 253402300799n;
 
 const portalRegistryAbi = parseAbi([
   "function clusterCount() view returns (uint256)",
@@ -90,15 +91,17 @@ type TokenMetadata = { decimals: number; symbol: string };
 const tokenMetadataCache = new Map<Address, TokenMetadata>();
 
 async function fetchPools(): Promise<Pool[]> {
+  if (!portalRegistryAddress) return [];
+
   const count = await client.readContract({
-    address: portalRegistryAddress as Address,
+    address: portalRegistryAddress,
     abi: portalRegistryAbi,
     functionName: "clusterCount",
   });
   if (count === 0n) return [];
 
   const [, clusters] = await client.readContract({
-    address: portalRegistryAddress as Address,
+    address: portalRegistryAddress,
     abi: portalRegistryAbi,
     functionName: "getClustersPaginated",
     args: [0n, count],
@@ -216,8 +219,8 @@ function setGauges(poolData: PoolData[]) {
       if (runway < 0n) {
         // Should not occur on a healthy pool; surface as 0 to make dashboards visible.
         runwaySeconds = 0;
-      } else if (runway > BigInt(RUNWAY_INFINITY_CAP)) {
-        runwaySeconds = RUNWAY_INFINITY_CAP;
+      } else if (runway > RUNWAY_INFINITY_CAP) {
+        runwaySeconds = Number(RUNWAY_INFINITY_CAP);
       } else {
         runwaySeconds = Number(runway);
       }
@@ -256,9 +259,7 @@ export async function updatePortalMetrics() {
   if (!hasPortalToMonitor) return;
 
   const pools = await fetchPools();
-  if (pools.length === 0) return;
-
-  const poolData = await fetchPoolData(pools);
+  const poolData = pools.length > 0 ? await fetchPoolData(pools) : [];
 
   const uniqueTokens = Array.from(
     new Set(poolData.map((p) => p.rewardToken).filter((t): t is Address => !!t)),
@@ -267,5 +268,11 @@ export async function updatePortalMetrics() {
 
   await fetchErc20Balances(poolData);
 
+  // Reset only after all reads succeeded so transient RPC failures keep stale values
+  // visible; on success this clears series for pools/labels that no longer apply
+  // (removed from registry, dropped from allowlist, active flipped, reward token changed).
+  portalRunwayGauge.reset();
+  portalRewardBalanceGauge.reset();
+  portalRewardErc20BalanceGauge.reset();
   setGauges(poolData);
 }

--- a/packages/balance-monitor/src/server.ts
+++ b/packages/balance-monitor/src/server.ts
@@ -1,0 +1,16 @@
+import express from "express";
+import promClient from "prom-client";
+
+export function startServer() {
+  const app = express();
+  const port = process.env.PORT ?? 3000;
+
+  app.get("/metrics", async (_, res) => {
+    res.set("Content-Type", promClient.register.contentType);
+    res.end(await promClient.register.metrics());
+  });
+
+  app.listen(port, () => {
+    console.log(`Server listening at ${port}`);
+  });
+}

--- a/packages/balance-monitor/src/wallets.ts
+++ b/packages/balance-monitor/src/wallets.ts
@@ -1,4 +1,4 @@
-import { formatEther, parseAbi, type Address } from "viem";
+import { formatEther, formatUnits, parseAbi, type Address } from "viem";
 import { arbitrum } from "viem/chains";
 import promClient from "prom-client";
 import { chainId, client } from "./client.js";
@@ -74,7 +74,7 @@ export async function updateWalletMetrics() {
     if (res.status === "success") {
       balanceGauge.set(
         { wallet: sqdBalanceWallets[i], token: "SQD" },
-        Number(formatEther(res.result)),
+        Number(formatUnits(res.result, 18)),
       );
     }
   }

--- a/packages/balance-monitor/src/wallets.ts
+++ b/packages/balance-monitor/src/wallets.ts
@@ -1,0 +1,81 @@
+import { formatEther, parseAbi, type Address } from "viem";
+import { arbitrum } from "viem/chains";
+import promClient from "prom-client";
+import { chainId, client } from "./client.js";
+
+const ethBalanceWallets = (process.env.ETH_HOLDERS ?? "")
+  .split(",")
+  .map((a) => a.trim())
+  .filter(Boolean) as Address[];
+
+const sqdBalanceWallets = (process.env.SQD_HOLDERS ?? "")
+  .split(",")
+  .map((a) => a.trim())
+  .filter(Boolean) as Address[];
+
+export const hasWalletsToMonitor =
+  ethBalanceWallets.length + sqdBalanceWallets.length > 0;
+
+const sqdTokenAddress: Address =
+  chainId === arbitrum.id
+    ? "0x1337420dED5ADb9980CFc35f8f2B054ea86f8aB1"
+    : "0x24f9C46d86c064a6FA2a568F918fe62fC6917B3c";
+
+const multicallAbi = parseAbi([
+  "function getEthBalance(address) view returns (uint256)",
+]);
+const tokenAbi = parseAbi([
+  "function balanceOf(address) view returns (uint256)",
+]);
+
+const balanceGauge = new promClient.Gauge({
+  name: "sqd_wallet_balance",
+  help: "Balance of the wallet",
+  labelNames: ["wallet", "token"],
+});
+
+export async function updateWalletMetrics() {
+  if (!hasWalletsToMonitor) return;
+
+  const ethCalls = ethBalanceWallets.map(
+    (address) =>
+      ({
+        address: client.chain.contracts.multicall3.address,
+        abi: multicallAbi,
+        functionName: "getEthBalance",
+        args: [address],
+      }) as const,
+  );
+  const sqdCalls = sqdBalanceWallets.map(
+    (address) =>
+      ({
+        address: sqdTokenAddress,
+        abi: tokenAbi,
+        functionName: "balanceOf",
+        args: [address],
+      }) as const,
+  );
+
+  const results = await client.multicall({
+    contracts: [...ethCalls, ...sqdCalls],
+  });
+
+  for (let i = 0; i < ethCalls.length; i++) {
+    const res = results[i];
+    if (res.status === "success") {
+      balanceGauge.set(
+        { wallet: ethBalanceWallets[i], token: "ETH" },
+        Number(formatEther(res.result)),
+      );
+    }
+  }
+  for (let i = 0; i < sqdCalls.length; i++) {
+    const res = results[ethCalls.length + i];
+    if (res.status === "success") {
+      balanceGauge.set(
+        { wallet: sqdBalanceWallets[i], token: "SQD" },
+        Number(formatEther(res.result)),
+      );
+    }
+  }
+}


### PR DESCRIPTION
Added portal metrics to balance monitor when both `PORTAL_REGISTRY` and `PORTAL_OPERATORS ` are set.

Also split the package into multiple files for easier reading.

Existing metrics left as they were