### PR TITLE
fix(rewards-calculator): make reward commitment ordering deterministic

### DIFF
--- a/packages/rewards-calculator/src/chain.ts
+++ b/packages/rewards-calculator/src/chain.ts
@@ -15,6 +15,7 @@ import { Rewards } from "./reward";
 import { Workers } from "./workers";
 import { fordefiRequest } from "./fordefi/request";
 import { sendFordefiTransaction } from "./fordefi/sendTransaction";
+import { rewardsToTxArgs } from "./rewardsToTxArgs";
 import assert from "assert";
 
 const MAX_BLOCK_RANGE_SIZE = BigInt(config.logScanMaxRange)
@@ -238,17 +239,6 @@ export async function getBlockTimestamp(blockNumber: number) {
 
 export async function canCommit(address: Hex) {
   return contracts.rewardsDistribution.read.canCommit([address]);
-}
-
-function rewardsToTxArgs(rewards: Rewards) {
-  const workerPeerIds = Object.keys(rewards ?? {});
-  const workerIds = workerPeerIds.map((id) => rewards[id].id);
-  const rewardAmounts = workerPeerIds.map((id) => rewards[id].workerReward);
-  const stakedAmounts = workerPeerIds.map((id) => rewards[id].stakerReward);
-  const computationUnitsUsed = workerPeerIds.map(
-    (id) => rewards[id].computationUnitsUsed ?? 0n,
-  );
-  return { workerIds, rewardAmounts, stakedAmounts, computationUnitsUsed };
 }
 
 async function sendCommitRequest(

--- a/packages/rewards-calculator/src/clickhouseClient.ts
+++ b/packages/rewards-calculator/src/clickhouseClient.ts
@@ -50,6 +50,7 @@ export class ClickhouseClient {
           ${config.clickhouse.logsTableName}.worker_timestamp <= '${formatDate(this.to)}' and
           (toUnixTimestamp64Micro(collector_timestamp) - toUnixTimestamp64Micro(worker_timestamp)) / 60000000 < 20
         group by worker_id
+        order by worker_id
       `;
       const res: any[] = await clickhouse.query(query).toPromise()
 

--- a/packages/rewards-calculator/src/rewardsToTxArgs.ts
+++ b/packages/rewards-calculator/src/rewardsToTxArgs.ts
@@ -1,0 +1,27 @@
+import type { Rewards } from "./reward";
+
+/**
+ * Build the on-chain commit/approve arguments from the computed rewards.
+ *
+ * The on-chain commitment is `keccak256` over the ABI-encoded
+ * `(recipients, workerRewards, stakerRewards)` arrays, so their ORDER is part of
+ * the hash. Every distributor must produce byte-identical calldata for a commit
+ * to collect the required approvals and distribute.
+ *
+ * `Object.keys` order follows ClickHouse's row order, which is NOT stable across
+ * processes or even repeated queries: parallel `GROUP BY` has no guaranteed
+ * output order. If bots derive different orderings they compute different
+ * commitment hashes, approvals never match, and distribution stalls (see the
+ * June 2026 incident). Sorting by peerId makes the ordering deterministic and
+ * identical for every bot, independent of ClickHouse physical layout / threads.
+ */
+export function rewardsToTxArgs(rewards: Rewards) {
+  const workerPeerIds = Object.keys(rewards ?? {}).sort();
+  const workerIds = workerPeerIds.map((id) => rewards[id].id);
+  const rewardAmounts = workerPeerIds.map((id) => rewards[id].workerReward);
+  const stakedAmounts = workerPeerIds.map((id) => rewards[id].stakerReward);
+  const computationUnitsUsed = workerPeerIds.map(
+    (id) => rewards[id].computationUnitsUsed ?? 0n,
+  );
+  return { workerIds, rewardAmounts, stakedAmounts, computationUnitsUsed };
+}

--- a/packages/rewards-calculator/test/rewards-tx-args.ts
+++ b/packages/rewards-calculator/test/rewards-tx-args.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+import { rewardsToTxArgs } from "../src/rewardsToTxArgs";
+import type { Rewards } from "../src/reward";
+
+function reward(id: bigint, worker: bigint, staker: bigint) {
+  return {
+    id,
+    workerReward: worker,
+    stakerReward: staker,
+    computationUnitsUsed: Number(id),
+  };
+}
+
+// Same rewards, but the keys are inserted in two different orders to emulate
+// ClickHouse returning rows in a non-deterministic order between bots/runs.
+function buildInScrambledOrders(): [Rewards, Rewards] {
+  const entries: Array<[string, ReturnType<typeof reward>]> = [
+    ["12D3KooWcZZZ", reward(3n, 300n, 30n)],
+    ["12D3KooWaAAA", reward(1n, 100n, 10n)],
+    ["12D3KooWbMMM", reward(2n, 200n, 20n)],
+    ["12D3KooWdNNN", reward(4n, 400n, 40n)],
+  ];
+  const a: Rewards = {};
+  for (const [k, v] of entries) a[k] = v;
+  const b: Rewards = {};
+  for (const [k, v] of [...entries].reverse()) b[k] = v;
+  return [a, b];
+}
+
+describe("rewardsToTxArgs", () => {
+  it("orders recipients by peerId regardless of insertion order", () => {
+    const [a] = buildInScrambledOrders();
+    const { workerIds, rewardAmounts, stakedAmounts } = rewardsToTxArgs(a);
+    // sorted peerIds: aAAA(1), bMMM(2), cZZZ(3), dNNN(4)
+    expect(workerIds).to.deep.equal([1n, 2n, 3n, 4n]);
+    expect(rewardAmounts).to.deep.equal([100n, 200n, 300n, 400n]);
+    expect(stakedAmounts).to.deep.equal([10n, 20n, 30n, 40n]);
+  });
+
+  it("is deterministic: different insertion orders yield identical args", () => {
+    const [a, b] = buildInScrambledOrders();
+    const argsA = rewardsToTxArgs(a);
+    const argsB = rewardsToTxArgs(b);
+    // This is the invariant the on-chain commitment hash depends on. If it ever
+    // breaks, distributors compute different hashes and distribution stalls.
+    expect(argsA).to.deep.equal(argsB);
+  });
+
+  it("handles empty rewards", () => {
+    const { workerIds, rewardAmounts, stakedAmounts } = rewardsToTxArgs(
+      {} as Rewards,
+    );
+    expect(workerIds).to.deep.equal([]);
+    expect(rewardAmounts).to.deep.equal([]);
+    expect(stakedAmounts).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary

Reward distribution on mainnet **stalled for ~19h+ starting Jun 22 13:13 UTC**: a commitment for the next block range kept being re-committed (27+ times, each a different hash) and never reached the 2-of-3 approval quorum, so `lastBlockRewarded` froze and no rewards were distributed.

**Root cause:** the on-chain commitment is `keccak256` over the ABI-encoded `(recipients, workerRewards, stakerRewards)` arrays, so their **order** is part of the hash. The bot built these from `Object.keys(rewards)`, whose order follows ClickHouse's row order. The production (skip-signature) query has **no `ORDER BY`**, and ClickHouse's parallel `GROUP BY` gives no guaranteed output order — so independent distributor bots (and even repeated runs) produced the **same workers/values in different order → different hashes → approvals never matched**.

Decoding two stuck commits confirmed it: identical worker set, identical per-worker values, **different order only**. The nondeterminism is parallel aggregation (`max_threads=1` is deterministic; `auto(8)` is not). This was latent for months and surfaced when a change to ClickHouse physical layout/threads made the `GROUP BY` order non-reproducible.

## Fix

- Extract `rewardsToTxArgs` into its own config-free module and **sort recipients by peerId**, so every bot derives the same order deterministically — independent of ClickHouse layout, threads, or codec. This covers `commit`, `approve`, and `recommit` (all route through it).
- Add `order by worker_id` to the skip-signature query as defense in depth.
- Add unit tests for the determinism invariant (two scrambled insertion orders must yield byte-identical args).

## Test

```
TS_NODE_TRANSPILE_ONLY=true npx mocha test/rewards-tx-args.ts
  rewardsToTxArgs
    ✔ orders recipients by peerId regardless of insertion order
    ✔ is deterministic: different insertion orders yield identical args
    ✔ handles empty rewards
  3 passing
```

## Deploy / recovery notes

- **All 3 distributor bots must run this image.** Convergence needs ≥2 bots producing identical (sorted) calldata; during a rolling deploy old+new won't match until at least two are on the new code.
- On full rollout, the bots **self-recover**: the stale 1/2 commitment is harmlessly overwritten by the first new-code commit, the stuck range reaches quorum and distributes, and the bot then advances contiguously through the ~10-epoch pending backlog (~1–2h). Those backlog windows have real settled data, so they pay correct non-zero rewards.
- **Not auto-recovered:** epochs already distributed at `0` during the Jun 7 (pings) and Jun 20–21 (query-logs ingestion) incidents are finalized on-chain and require a separate top-up.
- Optional immediate stopgap before deploy: `SET max_threads=1` on the bot's ClickHouse profile restores determinism without a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)